### PR TITLE
Implement the free speaking feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/generative-ai-go v0.20.1
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.6 h1:GW/XbdyBFQ8Qe+YAmFU
 github.com/googleapis/enterprise-certificate-proxy v0.3.6/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81vgd/bo=
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/internal/client/elevenlabs_client.go
+++ b/internal/client/elevenlabs_client.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+)
+
+type ElevenLabsTTSClient struct {
+	apiKey  string
+	voiceID string
+	client  *http.Client
+}
+
+type ttsRequest struct {
+	Text          string         `json:"text"`
+	ModelID       string         `json:"model_id"`
+	VoiceSettings *voiceSettings `json:"voice_settings"`
+}
+
+type voiceSettings struct {
+	Stability       float64 `json:"stability"`
+	SimilarityBoost float64 `json:"similarity_boost"`
+}
+
+func NewElevenLabsTTSClient(apiKey, voiceID string) *ElevenLabsTTSClient {
+	return &ElevenLabsTTSClient{
+		apiKey:  apiKey,
+		voiceID: voiceID,
+		client:  &http.Client{},
+	}
+}
+
+func (c *ElevenLabsTTSClient) GenerateAudio(text string) ([]byte, error) {
+	url := fmt.Sprintf("https://api.elevenlabs.io/v1/text-to-speech/%s", c.voiceID)
+	payload := ttsRequest{
+		Text:    text,
+		ModelID: "eleven_multilingual_v2",
+		VoiceSettings: &voiceSettings{
+			Stability:       0.5,
+			SimilarityBoost: 0.75,
+		},
+	}
+	jsonData, _ := json.Marshal(payload)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("xi-api-key", c.apiKey)
+	req.Header.Set("Accept", "audio/mpeg")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		b, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("ElevenLabs API error: %s", string(b))
+	}
+
+	return ioutil.ReadAll(resp.Body)
+}
+
+func (c *ElevenLabsTTSClient) PlayAudio(audioData []byte) error {
+	tmpFile, err := ioutil.TempFile("", "tts_*.mp3")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tmpFile.Write(audioData)
+	tmpFile.Close()
+
+	cmd := exec.Command("ffplay", "-autoexit", "-nodisp", tmpFile.Name())
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run()
+}

--- a/internal/client/groq_client.go
+++ b/internal/client/groq_client.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+type GroqClient struct {
+	apiKey string
+	client *http.Client
+}
+
+type GroqRequest struct {
+	Model    string        `json:"model"`
+	Messages []GroqMessage `json:"messages"`
+}
+type GroqMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+type GroqResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+func NewGroqClient(apiKey string) *GroqClient {
+	return &GroqClient{apiKey: apiKey, client: &http.Client{}}
+}
+
+func (c *GroqClient) GenerateContent(ctx context.Context, prompt string) (string, error) {
+	reqBody := GroqRequest{
+		Model:    "llama3-8b-8192",
+		Messages: []GroqMessage{{Role: "user", Content: prompt}},
+	}
+	data, _ := json.Marshal(reqBody)
+	req, _ := http.NewRequestWithContext(ctx, "POST", "https://api.groq.com/openai/v1/chat/completions", bytes.NewBuffer(data))
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var gr GroqResponse
+	if err := json.NewDecoder(resp.Body).Decode(&gr); err != nil {
+		return "", err
+	}
+	if len(gr.Choices) > 0 {
+		return gr.Choices[0].Message.Content, nil
+	}
+	return "", errors.New("no content returned")
+}

--- a/internal/client/whisper_client.go
+++ b/internal/client/whisper_client.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type WhisperClient struct {
+	apiKey string
+	client *http.Client
+}
+
+type WhisperResponse struct {
+	Text string `json:"text"`
+}
+type WhisperErrorResponse struct {
+	Error         string  `json:"error"`
+	EstimatedTime float64 `json:"estimated_time,omitempty"`
+}
+
+func NewWhisperClient(apiKey string) *WhisperClient {
+	return &WhisperClient{
+		apiKey: apiKey,
+		client: &http.Client{},
+	}
+}
+
+func (c *WhisperClient) Transcribe(ctx context.Context, audioData []byte) (string, error) {
+	url := "https://api-inference.huggingface.co/models/openai/whisper-large-v3"
+
+	for i := 0; i < 3; i++ {
+		req, _ := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(audioData))
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+		req.Header.Set("Content-Type", "audio/ogg")
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+
+		body, _ := ioutil.ReadAll(resp.Body)
+
+		if resp.StatusCode == 200 {
+			var wr WhisperResponse
+			if err := json.Unmarshal(body, &wr); err != nil {
+				return "", fmt.Errorf("parse error: %w, body: %s", err, string(body))
+			}
+			return wr.Text, nil
+		}
+
+		var we WhisperErrorResponse
+		if err := json.Unmarshal(body, &we); err == nil && strings.Contains(strings.ToLower(we.Error), "loading") {
+			waitTime := time.Duration(we.EstimatedTime+2) * time.Second
+			time.Sleep(waitTime)
+			continue
+		}
+		return "", errors.New("unexpected Whisper response")
+	}
+	return "", errors.New("model did not load in time")
+}

--- a/internal/domain/entities/speaking.go
+++ b/internal/domain/entities/speaking.go
@@ -1,0 +1,5 @@
+package entities
+
+type SpeakingResponse struct {
+	Feedback string `json:"feedback"`
+}

--- a/internal/handler/speaking_handler.go
+++ b/internal/handler/speaking_handler.go
@@ -1,0 +1,78 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"lissanai.com/backend/internal/service"
+)
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+// ControlMessage defines the structure for text-based commands.
+type ControlMessage struct {
+	Type string `json:"type"`
+}
+
+// --- CHANGE #1: THE STRUCT FIELD ---
+// The handler now holds the INTERFACE.
+type ConversationHandler struct {
+	speakingService service.SpeakingService
+}
+
+// --- CHANGE #2: THE CONSTRUCTOR PARAMETER ---
+// The constructor now accepts the INTERFACE.
+func NewConversationHandler(s *service.SpeakingService) *ConversationHandler {
+	return &ConversationHandler{speakingService: *s}
+}
+
+// The HandleConversation method is correct as you wrote it.
+func (h *ConversationHandler) HandleConversation(c *gin.Context) {
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		log.Println("Upgrade failed:", err)
+		return
+	}
+	defer conn.Close()
+	log.Println("Client connected. Waiting for audio stream...")
+
+	var audioBuffer bytes.Buffer
+
+	for {
+		msgType, message, err := conn.ReadMessage()
+		if err != nil {
+			log.Println("Read error:", err)
+			break
+		}
+
+		switch msgType {
+		case websocket.BinaryMessage:
+			audioBuffer.Write(message)
+		case websocket.TextMessage:
+			var ctrlMsg ControlMessage
+			if err := json.Unmarshal(message, &ctrlMsg); err == nil && ctrlMsg.Type == "end_of_speech" {
+				if audioBuffer.Len() == 0 {
+					continue
+				}
+				log.Printf("End-of-speech received. Processing %d bytes.", audioBuffer.Len())
+
+				feedbackAudio, err := h.speakingService.ProcessAudioFeedback(context.Background(), audioBuffer.Bytes())
+				if err != nil {
+					log.Println("Processing error:", err)
+					audioBuffer.Reset()
+					continue
+				}
+
+				conn.WriteMessage(websocket.BinaryMessage, feedbackAudio)
+				audioBuffer.Reset()
+			}
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -111,7 +111,6 @@ func New() *gin.Engine {
 			chatAPI.POST("/answer", authMiddleware, chat_handler.SubmitAnswerHandler)
 			chatAPI.POST("/:session_id/end", authMiddleware, chat_handler.EndSessionHandler)
 
-			
 		}
 
 		// User routes (protected)
@@ -123,8 +122,8 @@ func New() *gin.Engine {
 			users.DELETE("/me", userHandler.DeleteAccount)
 			users.POST("/me/push-token", userHandler.AddPushToken)
 		}
-		
-				// Email routes (protected)
+
+		// Email routes (protected)
 		emailGroup := apiV1.Group("/")
 		_ = SetupEmailRoutes(emailGroup)
 		// Future routes for other features
@@ -132,6 +131,9 @@ func New() *gin.Engine {
 		// grammar := apiV1.Group("/grammar")
 		// pronunciation := apiV1.Group("/pronunciation")
 		// learning := apiV1.Group("/learning")
+
+		// Free Speaking route
+		SetupSpeakingRoutes(apiV1)
 	}
 
 	// --- Swagger ---

--- a/internal/server/speaking_server.go
+++ b/internal/server/speaking_server.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"log"
+	"os"
+
+	"github.com/gin-gonic/gin"
+	"github.com/joho/godotenv"
+	"lissanai.com/backend/internal/client"
+	"lissanai.com/backend/internal/handler"
+	"lissanai.com/backend/internal/service"
+)
+
+func SetupSpeakingRoutes(router *gin.RouterGroup) {
+	godotenv.Load() // optional .env
+
+	groqAPIKey := os.Getenv("GROQ_API_KEY")
+	hfAPIKey := os.Getenv("HF_API_KEY")
+	elevenLabsKey := os.Getenv("ELEVENLABS_API_KEY")
+	voiceID := os.Getenv("ELEVENLABS_VOICE_ID")
+
+	if groqAPIKey == "" || hfAPIKey == "" || elevenLabsKey == "" || voiceID == "" {
+		log.Fatal("Missing one or more API keys or voice ID")
+	}
+
+	groqClient := client.NewGroqClient(groqAPIKey)
+	whisperClient := client.NewWhisperClient(hfAPIKey)
+	elevenLabsClient := client.NewElevenLabsTTSClient(elevenLabsKey, voiceID)
+
+	speakingService := service.NewSpeakingService(groqClient, whisperClient, elevenLabsClient)
+	conversationHandler := handler.NewConversationHandler(speakingService)
+
+	router.GET("/ws/conversation", conversationHandler.HandleConversation)
+}

--- a/internal/service/speaking_service.go
+++ b/internal/service/speaking_service.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"lissanai.com/backend/internal/client"
+)
+
+type SpeakingService struct {
+	groqClient       *client.GroqClient
+	whisperClient    *client.WhisperClient
+	elevenLabsClient *client.ElevenLabsTTSClient
+}
+
+func NewSpeakingService(groq *client.GroqClient, whisper *client.WhisperClient, eleven *client.ElevenLabsTTSClient) *SpeakingService {
+	return &SpeakingService{
+		groqClient:       groq,
+		whisperClient:    whisper,
+		elevenLabsClient: eleven,
+	}
+}
+
+func (s *SpeakingService) ProcessAudioFeedback(ctx context.Context, audioData []byte) ([]byte, error) {
+	// 1️⃣ STT: Convert audio to text
+	text, err := s.whisperClient.Transcribe(ctx, audioData)
+	if err != nil {
+		return nil, fmt.Errorf("STT error: %w", err)
+	}
+
+	// 2️⃣ LLM: Generate response
+	response, err := s.groqClient.GenerateContent(ctx, text)
+	if err != nil {
+		return nil, fmt.Errorf("LLM error: %w", err)
+	}
+
+	// 🧹 Clean and trim response before TTS
+	cleanedResponse := strings.TrimSpace(response)
+	if len(cleanedResponse) > 100 {
+		cleanedResponse = cleanedResponse[:100]
+	}
+
+	// 3️⃣ TTS: Convert response to audio
+	ttsAudio, err := s.elevenLabsClient.GenerateAudio(cleanedResponse)
+	if err != nil {
+		return nil, fmt.Errorf("TTS error: %w", err)
+	}
+
+	return ttsAudio, nil
+}


### PR DESCRIPTION
- Adds a WebSocket endpoint at /api/v1/ws/conversation to handle the speaking feature.
- Implements a 'press-to-talk' model where audio is buffered and processed on an 'end_of_speech' signal.
- Integrates three external AI services for the pipeline:
  1. Whisper (Hugging Face) for Speech-to-Text.
  2. Groq (Llama3) for LLM feedback generation.
  3. ElevenLabs for Text-to-Speech.